### PR TITLE
Hide props on fold: invert rules

### DIFF
--- a/src/modules/awesomeProps/awesomeProps.css
+++ b/src/modules/awesomeProps/awesomeProps.css
@@ -13,11 +13,11 @@
     /* grid-gap: 1px 0; */
     /* background-color: #88888833; */
 }
-.ls-block:not([data-collapsed="false"]) .block-properties {
-    display: none !important;
-}
 .ls-block:not([data-collapsed]) .block-properties {
     display: grid !important;
+}
+.ls-block:not([data-collapsed="false"]) .block-properties {
+    display: none !important;
 }
 .block-properties > div {
     display: contents !important;


### PR DESCRIPTION
Hi,
I had two issue with hiding properties for collapsed blocks:

1. It didn't work for collpased blocks with no children (it's possible to collapse such blocks with this line in config.edn: `:outliner/block-title-collapse-enabled? true`)
2. It didn't work for any block as result of a query

Both are solved by simply inverting the two rules used to implementing that feature.

A side effect is that properties don't appear at all in query results, even if the blocks are not collapsed. Personally I'm OK with that and it's even better for me: properties in queries can be visualized better in table view.

-----

Not collapsed block with no children and multiple lines:
![image](https://user-images.githubusercontent.com/26327475/197788933-196b392b-c178-41f2-9de8-c9d1137f58b5.png)

Same but collapsed:
![image](https://user-images.githubusercontent.com/26327475/197789196-7aa3c2d7-be96-4012-9d5b-aa5dc784465e.png)

As query result, list view (properties never visible):

![image](https://user-images.githubusercontent.com/26327475/197789797-b4345ac8-37a5-499e-bb2c-e7118c5c317f.png)

As query result, table view:
![image](https://user-images.githubusercontent.com/26327475/197790007-1c77d4b9-e0d3-4b1a-aff4-6dd4d88621fe.png)

-----

I tested this for a day only, please test it too. Cheers.
